### PR TITLE
Disable LVDS module while not available yet

### DIFF
--- a/Drivers/STM32MP2xx_HAL_Driver/Inc/stm32mp2xx_hal_conf_template.h
+++ b/Drivers/STM32MP2xx_HAL_Driver/Inc/stm32mp2xx_hal_conf_template.h
@@ -65,7 +65,7 @@ extern "C" {
 #define HAL_IWDG_MODULE_ENABLED
 #define HAL_LPTIM_MODULE_ENABLED
 #define HAL_LTDC_MODULE_ENABLED
-#define HAL_LVDS_MODULE_ENABLED
+/* #define HAL_LVDS_MODULE_ENABLED */ /* Disabled because LVDS HAL not available yet */
 #define HAL_MDF_MODULE_ENABLED
 #define HAL_MMC_MODULE_ENABLED
 #define HAL_NAND_MODULE_ENABLED


### PR DESCRIPTION
LVDS HAL is not implemented yet, so it should not be activated